### PR TITLE
Fix Dockerfile and remove deprecated setDefaultTopicConf()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ php:
   - 7.1
   - nightly
 
+env:
+  - VERSION=3.0.1
+
 before_script:
   - composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - nightly
 
 env:
   - VERSION=3.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN docker-php-ext-install -j$(nproc) zip \
         && mkdir php-rdkafka \
         && cd php-rdkafka \
         && git clone https://github.com/arnaud-lb/php-rdkafka.git . \
-        && git checkout php7 \
+        && git checkout master \
         && phpize \
         && ./configure \
         && make -j$(nproc) \
@@ -60,4 +60,5 @@ COPY phpunit.xml /opt/laravel-pubsub/
 
 RUN composer dump-autoload --no-interaction
 
-CMD ["/bin/bash"]
+# Keep the container running so that can run tests manually
+CMD ["php-fpm"]

--- a/src/PubSubConnectionFactory.php
+++ b/src/PubSubConnectionFactory.php
@@ -91,11 +91,11 @@ class PubSubConnectionFactory
         $topicConf->set('auto.offset.reset', 'smallest');
 
         $conf = $this->container->makeWith('pubsub.kafka.conf');
+
         $conf->set('group.id', array_get($config, 'consumer_group_id', 'php-pubsub'));
         $conf->set('metadata.broker.list', $config['brokers']);
         $conf->set('enable.auto.commit', 'false');
         $conf->set('offset.store.method', 'broker');
-        $conf->setDefaultTopicConf($topicConf);
 
         $consumer = $this->container->makeWith('pubsub.kafka.consumer', ['conf' => $conf]);
 

--- a/tests/PubSubConnectionFactoryTest.php
+++ b/tests/PubSubConnectionFactoryTest.php
@@ -122,18 +122,15 @@ class PubSubConnectionFactoryTest extends TestCase
                 'broker',
             ])
             ->once();
-        $conf->shouldReceive('setDefaultTopicConf')
-            ->with($topicConf)
-            ->once();
 
-        $container->shouldReceive('make')
+        $container->shouldReceive('makeWith')
             ->with('pubsub.kafka.conf')
             ->once()
             ->andReturn($conf);
 
         $consumer = Mockery::mock(\RdKafka\KafkaConsumer::class);
 
-        $container->shouldReceive('make')
+        $container->shouldReceive('makeWith')
             ->withArgs([
                 'pubsub.kafka.consumer',
                 ['conf' => $conf],


### PR DESCRIPTION
- Fixed Dockerfile so actually builds!
- Removed call to setDefaultTopicConf() within PubSubConnectionFactory class bound to \RdKafka\Conf